### PR TITLE
Add support for JSONQL (issue #31).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,6 +371,35 @@ See how easy it is to generate a report with a source an JSON file:
         print('Result is the file below.')
         print(output + '.pdf')
 
+**Note 3:**
+
+JasperReports can process JSON files using either the `original JSON DataSource
+<http://jasperreports.sourceforge.net/sample.reference/jsondatasource/index.html>`__
+or the `newer JSONQL Data Source
+<http://jasperreports.sourceforge.net/sample.reference/jsonqldatasource/index.html>`__.
+Refer to the JSONQL DataSource documentation for the differences. The example above
+uses the JSON DataSource. To use the enhanced capabilities of the JSONQL DataSource
+instead use:
+
+-   the ``jsonql.jrxml`` input file
+-   the ``jsonql`` driver setting
+-   the ``jsonql_query`` query setting
+
+by changing these three parts of the example:
+
+.. code-block:: python
+
+    ...
+        input_file = os.path.dirname(os.path.abspath(__file__)) + \
+                     '/examples/jsonql.jrxml'
+    ...
+            db_connection={
+    ...
+                'driver': 'jsonql',
+                'jsonql_query': json_query,
+            },
+
+
 Subreport Example
 ~~~~~~~~~~~~~~~~~
 

--- a/examples/jsonql.jrxml
+++ b/examples/jsonql.jrxml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="json" language="groovy" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="8334f12e-a866-41de-8672-61a43ba44bab">
+	<property name="ireport.zoom" value="1.5"/>
+	<property name="ireport.x" value="0"/>
+	<property name="ireport.y" value="0"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="JsonQLAdapter"/>
+	<queryString language="jsonql">
+		<![CDATA[contacts.person]]>
+	</queryString>
+	<field name="name" class="java.lang.String">
+		<fieldDescription><![CDATA[name]]></fieldDescription>
+	</field>
+	<field name="street" class="java.lang.String">
+		<fieldDescription><![CDATA[street]]></fieldDescription>
+	</field>
+	<field name="city" class="java.lang.Integer">
+		<fieldDescription><![CDATA[city]]></fieldDescription>
+	</field>
+	<field name="phone" class="java.lang.String">
+		<fieldDescription><![CDATA[phone]]></fieldDescription>
+	</field>
+	<background>
+		<band/>
+	</background>
+	<title>
+		<band height="72">
+			<frame>
+				<reportElement mode="Opaque" x="-20" y="-20" width="595" height="92" backcolor="#006699" uuid="d6b7d5aa-5c6b-4106-9569-b0014b63e753"/>
+				<staticText>
+					<reportElement x="20" y="20" width="267" height="43" forecolor="#FFFFFF" uuid="2932e85f-a2d7-40d5-9dad-0b5ea669ad15"/>
+					<textElement>
+						<font size="34" isBold="true"/>
+					</textElement>
+					<text><![CDATA[JasperStarter]]></text>
+				</staticText>
+				<staticText>
+					<reportElement x="298" y="43" width="277" height="20" forecolor="#FFFFFF" uuid="04e1a0ed-0b0f-41d4-93e9-792d4fd37d28"/>
+					<textElement textAlignment="Right">
+						<font size="14" isBold="false"/>
+					</textElement>
+					<text><![CDATA[Report with JSONQL Datasource]]></text>
+				</staticText>
+			</frame>
+		</band>
+	</title>
+	<pageHeader>
+		<band height="13"/>
+	</pageHeader>
+	<columnHeader>
+		<band height="30">
+			<line>
+				<reportElement x="-20" y="21" width="595" height="1" forecolor="#666666" uuid="94019af3-607f-4b88-8274-5967c629b025"/>
+			</line>
+			<staticText>
+				<reportElement x="320" y="0" width="133" height="20" uuid="22f4dad5-dda1-4d8d-ba31-7122e51b0905"/>
+				<textElement>
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[City]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="3" y="0" width="97" height="20" uuid="eaac8896-667b-4a63-adae-592cef191d8b"/>
+				<textElement>
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[Name]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="100" y="0" width="200" height="20" uuid="38ad2a59-8306-4869-af2d-619322df6d74"/>
+				<textElement>
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[Street]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="450" y="0" width="140" height="20" uuid="4fb0818d-4c85-4afb-b62c-4554822ea2b3"/>
+				<textElement>
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[Phone]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="24">
+			<textField>
+				<reportElement x="320" y="0" width="133" height="20" uuid="70a0f25d-aa46-4a62-8a96-e0d7955ebe5e"/>
+				<textFieldExpression><![CDATA[$F{city}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="3" y="0" width="97" height="20" uuid="ec4a8c9a-a5a6-49d8-945b-ef39b5a78e9c"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="100" y="0" width="200" height="20" uuid="8b120a86-15bc-453e-a672-b22d2178ce31"/>
+				<textFieldExpression><![CDATA[$F{street}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="450" y="0" width="140" height="20" uuid="37e3ac7f-7abf-4415-9014-98a4eab36f59"/>
+				<textFieldExpression><![CDATA[$F{phone}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<columnFooter>
+		<band/>
+	</columnFooter>
+	<pageFooter>
+		<band height="17">
+			<textField>
+				<reportElement mode="Opaque" x="0" y="4" width="515" height="13" backcolor="#E6E6E6" uuid="9d494e45-7fa2-4a24-9861-eee79cced51a"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement mode="Opaque" x="515" y="4" width="40" height="13" backcolor="#E6E6E6" uuid="63ea56af-97fd-481f-8faa-e2bcd65f6c15"/>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField pattern="EEEEE dd MMMMM yyyy">
+				<reportElement x="0" y="4" width="100" height="13" uuid="1822668b-e69e-4104-ba0b-0af0db204142"/>
+				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<summary>
+		<band/>
+	</summary>
+</jasperReport>

--- a/examples/jsonql.jrxml
+++ b/examples/jsonql.jrxml
@@ -14,7 +14,7 @@
 	<field name="street" class="java.lang.String">
 		<fieldDescription><![CDATA[street]]></fieldDescription>
 	</field>
-	<field name="city" class="java.lang.Integer">
+	<field name="city" class="java.lang.String">
 		<fieldDescription><![CDATA[city]]></fieldDescription>
 	</field>
 	<field name="phone" class="java.lang.String">

--- a/pyreportjasper/jasperpy.py
+++ b/pyreportjasper/jasperpy.py
@@ -137,6 +137,9 @@ class JasperPy:
             if 'json_query' in db_connection:
                 command += ' --json-query ' + db_connection['json_query']
 
+            if 'jsonql_query' in db_connection:
+                command += ' --jsonql-query ' + db_connection['jsonql_query']
+
         if resource != "":
             if (resource == "."):
                 command += " -r "

--- a/test/jasperpy_test.py
+++ b/test/jasperpy_test.py
@@ -97,3 +97,21 @@ class TestJasperPy(TestCase):
                 resource='examples/subreports/'
             ), 0)
 
+    def test_jsonql(self):
+        self.input_file = 'examples/jsonql.jrxml'
+
+        data_file = 'examples/contacts.json'
+
+        self.assertEqual(
+            self.jasper.process(
+                self.input_file,
+                format_list=["pdf"],
+                parameters={},
+                db_connection={
+                    'data_file': data_file,
+                    'driver': 'jsonql',
+                    'jsonql_query': 'contacts.person',
+                },
+                locale='pt_BR',  # LOCALE Ex.:(en_US, de_GE)
+            ), 0)
+


### PR DESCRIPTION
I added support for the JSONQL 'driver' setting and the corresponding 'json_query' in the db_connections, a sample jsonql.jrxml file, as well as some supporting text in the README.rst file.

Please consider.